### PR TITLE
Fixed some explicit coercion needs.

### DIFF
--- a/lib/ezjsonm.ml
+++ b/lib/ezjsonm.ml
@@ -107,7 +107,7 @@ let string_of_error error =
   Jsonm.pp_error Format.str_formatter error;
   Format.flush_str_formatter ()
 
-let from_src src: t =
+let from_src src =
   match json_of_src src with
   | `JSON t      -> t
   | `Error (_,e) -> parse_error `Null "JSON.of_buffer %s" (string_of_error e)

--- a/lib/ezjsonm.mli
+++ b/lib/ezjsonm.mli
@@ -45,7 +45,7 @@ type t =
 val value: t -> value
 (** Cast a JSON well-formed document into a JSON fragment. *)
 
-val wrap: value -> t
+val wrap: value -> [> t]
 (** [wrap v] wraps the value [v] into a JSON array. To use when it is
     not possible to statically know that [v] is a value JSON value. *)
 
@@ -55,13 +55,13 @@ val unwrap: t -> value
 
 (** {2 Reading JSON documents} *)
 
-val from_channel: in_channel -> t
+val from_channel: in_channel -> [> t]
 (** Read a JSON document from an input channel. *)
 
-val from_string: string -> t
+val from_string: string -> [> t]
 (** Read a JSON document from a string. *)
 
-val from_src: Jsonm.src -> t
+val from_src: Jsonm.src -> [> t]
 (** Low-level function to read directly from a [Jsonm] source. *)
 
 (** {2 Writing JSON documents} *)
@@ -90,7 +90,7 @@ val bool: bool -> value
 val string: string -> value
 (** Same as [`String s]. *)
 
-val strings: string list -> t
+val strings: string list -> [> t]
 (** Same as [`A [`String s1; ..; `String sn]]. *)
 
 val int: int -> value
@@ -105,20 +105,20 @@ val int64: int64 -> value
 val float: float -> value
 (** Some as [`Float f]. *)
 
-val list: ('a -> value) -> 'a list -> t
+val list: ('a -> value) -> 'a list -> [> t]
 (** Build a list of values. *)
 
 val option: ('a -> value) -> 'a option -> value
 (** Either [`Null] or a JSON value. *)
 
-val dict: (string * value) list -> t
+val dict: (string * value) list -> [> t]
 (** Build a dictionnary. *)
 
-val pair: ('a -> value) -> ('b -> value) -> ('a * 'b) -> t
+val pair: ('a -> value) -> ('b -> value) -> ('a * 'b) -> [> t]
 (** Build a pair. *)
 
 val triple: ('a -> value) -> ('b -> value) -> ('c -> value) ->
-  ('a * 'b * 'c) -> t
+  ('a * 'b * 'c) -> [> t]
 (** Build a triple. *)
 
 (** {2 Accessors} *)

--- a/lib/ezjsonm.mli
+++ b/lib/ezjsonm.mli
@@ -90,7 +90,7 @@ val bool: bool -> value
 val string: string -> value
 (** Same as [`String s]. *)
 
-val strings: string list -> value
+val strings: string list -> t
 (** Same as [`A [`String s1; ..; `String sn]]. *)
 
 val int: int -> value
@@ -105,20 +105,20 @@ val int64: int64 -> value
 val float: float -> value
 (** Some as [`Float f]. *)
 
-val list: ('a -> value) -> 'a list -> value
+val list: ('a -> value) -> 'a list -> t
 (** Build a list of values. *)
 
 val option: ('a -> value) -> 'a option -> value
 (** Either [`Null] or a JSON value. *)
 
-val dict: (string * value) list -> value
+val dict: (string * value) list -> t
 (** Build a dictionnary. *)
 
-val pair: ('a -> value) -> ('b -> value) -> ('a * 'b) -> value
+val pair: ('a -> value) -> ('b -> value) -> ('a * 'b) -> t
 (** Build a pair. *)
 
 val triple: ('a -> value) -> ('b -> value) -> ('c -> value) ->
-  ('a * 'b * 'c) -> value
+  ('a * 'b * 'c) -> t
 (** Build a triple. *)
 
 (** {2 Accessors} *)


### PR DESCRIPTION
This patch aims to avoid some anoying coercions between `t` and `value`.

No change in API, backward compatibility should be respected.

*With this PR, `value` function should become useless, except for backward compatibility.*