### PR TITLE
constraint lower bound for lwt library

### DIFF
--- a/opam
+++ b/opam
@@ -29,3 +29,4 @@ depends: [
   "hex"
 ]
 depopts: ["lwt"]
+conflicts: ["lwt" {<"2.5"}]


### PR DESCRIPTION
The `Lwt.Infix` module was added rather recently, so for older lwt the will fail.