### PR TITLE
Satisfy sexplib interface

### DIFF
--- a/lib/ezjsonm.ml
+++ b/lib/ezjsonm.ml
@@ -282,6 +282,8 @@ let rec of_sexp = function
   | Sexplib.Type.Atom x -> encode_string x
   | Sexplib.Type.List l -> list of_sexp l
 
+let value_of_sexp = of_sexp
+
 let rec to_sexp json =
   match decode_string json with
   | Some s -> Sexplib.Type.Atom s
@@ -289,3 +291,5 @@ let rec to_sexp json =
     match json with
     | `A l -> Sexplib.Type.List (List.map to_sexp l)
     | _    -> parse_error json "Ezjsonm.to_sexp"
+
+let sexp_of_value = to_sexp

--- a/lib/ezjsonm.ml
+++ b/lib/ezjsonm.ml
@@ -284,6 +284,11 @@ let rec of_sexp = function
 
 let value_of_sexp = of_sexp
 
+let t_of_sexp s = match value_of_sexp s with
+  | `A x -> `A x
+  | `O x -> `O x
+  | _ -> failwith "Ezjsonm: t_of_sexp encountered a value (fragment) rather than a t"
+
 let rec to_sexp json =
   match decode_string json with
   | Some s -> Sexplib.Type.Atom s
@@ -293,3 +298,5 @@ let rec to_sexp json =
     | _    -> parse_error json "Ezjsonm.to_sexp"
 
 let sexp_of_value = to_sexp
+
+let sexp_of_t t = sexp_of_value @@ value t

--- a/lib/ezjsonm.mli
+++ b/lib/ezjsonm.mli
@@ -197,8 +197,14 @@ val decode_string_exn: value -> string
 val to_sexp: value -> Sexplib.Type.t
 (** Convert a JSON object to an S-expression. *)
 
+val sexp_of_value: value -> Sexplib.Type.t
+(** An alias of [to_sexp] *)
+
 val of_sexp: Sexplib.Type.t -> value
 (** Convert an S-expression to a JSON object. *)
+
+val value_of_sexp: Sexplib.Type.t -> value
+(** AN alias of [of_sexp] *)
 
 (** {2 Error handling} *)
 

--- a/lib/ezjsonm.mli
+++ b/lib/ezjsonm.mli
@@ -195,16 +195,22 @@ val decode_string_exn: value -> string
 (** Convert a JSON object to a (possibly non-valid UTF8) string. *)
 
 val to_sexp: value -> Sexplib.Type.t
-(** Convert a JSON object to an S-expression. *)
+(** Convert a JSON fragment to an S-expression. *)
 
 val sexp_of_value: value -> Sexplib.Type.t
 (** An alias of [to_sexp] *)
 
+val sexp_of_t: t -> Sexplib.Type.t
+(** Convert a JSON object to an S-expression *)
+
 val of_sexp: Sexplib.Type.t -> value
-(** Convert an S-expression to a JSON object. *)
+(** Convert an S-expression to a JSON fragment *)
 
 val value_of_sexp: Sexplib.Type.t -> value
 (** AN alias of [of_sexp] *)
+
+val t_of_sexp: Sexplib.Type.t -> t
+(** Convert an S-expression to a JSON object *)
 
 (** {2 Error handling} *)
 

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,6 +1,7 @@
 (executables
  ((names (test))
-  (libraries (alcotest ezjsonm ezjsonm.lwt lwt.unix))
+  (libraries (alcotest ezjsonm ezjsonm-lwt lwt.unix))
+  (preprocess (pps (ppx_sexp_conv)))
 ))
 (alias
  ((name    runtest)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -1,5 +1,10 @@
 open Alcotest
 
+(* Check we're compatible with sexplib *)
+type test = {
+  foo: Ezjsonm.value;
+} [@@deriving sexp]
+
 let json_t: Ezjsonm.t Alcotest.testable =
   (module struct
     type t = Ezjsonm.t

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -3,6 +3,7 @@ open Alcotest
 (* Check we're compatible with sexplib *)
 type test = {
   foo: Ezjsonm.value;
+  bar: Ezjsonm.t;
 } [@@deriving sexp]
 
 let json_t: Ezjsonm.t Alcotest.testable =
@@ -89,6 +90,18 @@ let tests t ts () = List.iter (test t) ts
 let stream0 =
   random_list 42 (fun i -> Ezjsonm.(string @@ random_string i))
 
+let test_sexp_of_t () =
+  let t = `A [ `String "hello" ] in
+  let open Ezjsonm in
+  let t'' = t_of_sexp @@ sexp_of_t t in
+  Alcotest.(check json_t) "sexp_of_t" t t''
+
+let test_sexp_of_value () =
+  let v = `A [ `String "hello" ] in
+  let open Ezjsonm in
+  let v'' = value_of_sexp @@ sexp_of_value v in
+  Alcotest.(check json_v) "sexp_of_value" v v''
+
 let () =
   let suite k (t, ts) = k, ["test", `Quick, tests t ts] in
   Alcotest.run "ezjsonm" [
@@ -96,5 +109,9 @@ let () =
     suite "list"   list;
     "stream", [
       "stream0", `Quick, test_stream stream0;
-    ]
+    ];
+    "sexp", [
+      "sexp_of_t", `Quick, test_sexp_of_t;
+      "sexp_of_value", `Quick, test_sexp_of_value;
+    ];
   ]


### PR DESCRIPTION
- add `t_of_sexp`, `sexp_of_t`, `value_of_sexp`, `sexp_of_value` to satisfy the sexplib interface
- verify the interface is satisfied by adding a `[@@deriving sexp]`-based test case
- add a pair of simple positive test cases for `t_of_sexp (sexp_of_t t) = t` and `value_of_sexp  (sexp_of_value v) = v`

Fixes #24 