### PR TITLE
Add `value_to_*` and `value_from_*` methods to support RFC 7159/ECMA-404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
     - PINS="ezjsonm:."
     - PACKAGE=ezjsonm-lwt
   matrix:
-    - OCAML_VERSION=4.02
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.06

--- a/ezjsonm-lwt.opam
+++ b/ezjsonm-lwt.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {build & >= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_sexp_conv" {with-test}
-  "jsonm" {>= "0.9.1"}
+  "jsonm" {>= "1.0.0"}
   "sexplib"
   "hex"
   "lwt" {>= "2.5.0"}

--- a/ezjsonm.opam
+++ b/ezjsonm.opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>="4.03.0"}
   "dune" {build & >= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
-  "jsonm" {>= "0.9.1"}
+  "jsonm" {>= "1.0.0"}
   "sexplib"
   "hex"
 ]

--- a/lib/ezjsonm.mli
+++ b/lib/ezjsonm.mli
@@ -53,7 +53,7 @@ val unwrap: t -> value
 (** [unwrap t] is the reverse of [wrap]. It expects [t] to be a
     singleton JSON object and it return the unique element. *)
 
-(** {2 Reading JSON documents} *)
+(** {2 Reading JSON documents and values} *)
 
 val from_channel: in_channel -> [> t]
 (** Read a JSON document from an input channel. *)
@@ -61,10 +61,16 @@ val from_channel: in_channel -> [> t]
 val from_string: string -> [> t]
 (** Read a JSON document from a string. *)
 
-val from_src: Jsonm.src -> [> t]
+val value_from_channel: in_channel -> value
+(** Read a JSON value from an input channel. *)
+
+val value_from_string: string -> value
+(** Read a JSON value from a string. *)
+
+val value_from_src: Jsonm.src -> value
 (** Low-level function to read directly from a [Jsonm] source. *)
 
-(** {2 Writing JSON documents} *)
+(** {2 Writing JSON documents and values} *)
 
 val to_channel: ?minify:bool -> out_channel -> t -> unit
 (** Write a JSON document to an output channel. *)
@@ -76,7 +82,17 @@ val to_string: ?minify:bool -> t -> string
 (** Write a JSON document to a string. This goes via an intermediate
     buffer and so may be slow on large documents. *)
 
-val to_dst: ?minify:bool -> Jsonm.dst-> t -> unit
+val value_to_channel: ?minify:bool -> out_channel -> value -> unit
+(** Write a JSON value to an output channel. *)
+
+val value_to_buffer: ?minify:bool -> Buffer.t -> value -> unit
+(** Write a JSON value to a buffer. *)
+
+val value_to_string: ?minify:bool -> value -> string
+(** Write a JSON value to a string. This goes via an intermediate
+    buffer and so may be slow on large documents. *)
+
+val value_to_dst: ?minify:bool -> Jsonm.dst-> value -> unit
 (** Low-level function to write directly to a [Jsonm] destination. *)
 
 (** {2 Constructors} *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -15,7 +15,7 @@ let json_v: Ezjsonm.value Alcotest.testable =
   (module struct
     type t = Ezjsonm.value
     let equal = (=)
-    let pp ppf x = Format.pp_print_string ppf Ezjsonm.(to_string @@ wrap x)
+    let pp ppf x = Format.pp_print_string ppf Ezjsonm.(value_to_string x)
   end)
 
 let random_int i =
@@ -45,8 +45,8 @@ let test x t =
   let j =  x.to_json t in
   let t' = x.of_json j in
   Alcotest.(check x.test) "idempotent JSON conversion" t t';
-  let str = Ezjsonm.(to_string (wrap j)) in
-  let j' = Ezjsonm.(unwrap (from_string str)) in
+  let str = Ezjsonm.(value_to_string j) in
+  let j' = Ezjsonm.(value_from_string str) in
   let t' = x.of_json j' in
   Alcotest.(check x.test) "idempotent string conversion" t t'
 


### PR DESCRIPTION
See #5 for a past discussion of this.

Jsonm [as of v1.0.0](https://github.com/dbuenzli/jsonm/blob/master/CHANGES.md#v100-2016-11-23-zagreb) supports RFC 7159/ECMA-404, so this library can too!

Test Plan:
`dune runtest`

The tests have been updated to use the underlying `value_to_string` and `value_from_string` where appropriate, so they are fully tested.