### PR TITLE
Use a tail-recursive implementation of List.map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
     - PINS="ezjsonm:."
     - PACKAGE=ezjsonm-lwt
   matrix:
-    - OCAML_VERSION=4.02
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.06

--- a/lib/ezjsonm.ml
+++ b/lib/ezjsonm.ml
@@ -31,6 +31,13 @@ let value: t -> value = fun t -> (t :> value)
 
 exception Escape of ((int * int) * (int * int)) * Jsonm.error
 
+module List = struct
+  include List
+
+  (* Tail-recursive List.map *)
+  let map f l = rev (rev_map f l)
+end
+
 let json_of_src src =
   let d = Jsonm.decoder src in
   let dec () = match Jsonm.decode d with
@@ -154,7 +161,7 @@ let get_int64 = function
   | `Float f -> Int64.of_float f
   | j        -> parse_error j "Ezjsonm.get_int64"
 
-(* flooat *)
+(* float *)
 let float f = `Float f
 
 let get_float = function


### PR DESCRIPTION
This should reduce the chances of ezjsonm exploding on large json data.