### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/ezjsonm-lwt.opam
+++ b/ezjsonm-lwt.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/ezjsonm/issues"
 depends: [
   "ocaml"
   "ezjsonm"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
   "ppx_sexp_conv" {with-test}
   "jsonm" {>= "1.0.0"}

--- a/ezjsonm.opam
+++ b/ezjsonm.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ezjsonm/"
 bug-reports: "https://github.com/mirage/ezjsonm/issues"
 depends: [
   "ocaml" {>="4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "alcotest" {with-test & >= "0.4.0"}
   "jsonm" {>= "1.0.0"}
   "sexplib"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.