### PR TITLE
Fix assert failure and add find_opt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## v1.2.0 (2020-07-28)
 
+* Add `find_opt` to provide an exception-less version of `find` (#39 @avsm)
 * Raise `Parse_error` instead of assert failure if the input
   to `from_string` is not a valid JSON array or object (#39 @avsm).
 * Upgrade build rules to dune 2.0 (#38 @avsm)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 ## v1.2.0 (2020-07-28)
 
-* Upgrade build rules to dune 2.0 (@avsm)
+* Raise `Parse_error` instead of assert failure if the input
+  to `from_string` is not a valid JSON array or object (#39 @avsm).
+* Upgrade build rules to dune 2.0 (#38 @avsm)
 * Depend on Sexplib0 instead of Sexplib since we only need
   the type definition. This reduces the dependency cone of
-  Ezjsonm (and skips Base). (@avsm)
+  Ezjsonm (and skips Base). (#38 @avsm)
 
 ## v1.1.0 (2019-04-13)
 

--- a/lib/ezjsonm.ml
+++ b/lib/ezjsonm.ml
@@ -243,6 +243,9 @@ let find t path =
     | _           -> raise Not_found in
   aux t path
 
+let find_opt t path =
+  try Some (find t path) with Not_found -> None
+
 let map_dict f dict label =
   let rec aux acc = function
     | []    ->

--- a/lib/ezjsonm.ml
+++ b/lib/ezjsonm.ml
@@ -131,7 +131,7 @@ let value_from_channel chan = value_from_src (`Channel chan)
 
 let ensure_document: [> value] -> [> t] = function
   | #t as t -> t
-  | _ -> assert false
+  | t -> raise (Parse_error (t, "not a valid JSON array/object"))
 
 let from_string str = value_from_string str |> ensure_document
 

--- a/lib/ezjsonm.mli
+++ b/lib/ezjsonm.mli
@@ -187,11 +187,15 @@ val get_triple: (value -> 'a) -> (value -> 'b) -> (value -> 'c) ->
 (** {2 High-level functions} *)
 
 val mem: value -> string list -> bool
-(** Is the given path valid if the provided JSON document. *)
+(** [mem v path] is true if the given path is valid for the JSON document [v]. *)
 
 val find: value -> string list -> value
-(** Find the sub-document adressed by the given path. Raise
+(** Find the sub-document addressed by the given path. Raise
     [Not_found] if the path is invalid. *)
+
+val find_opt : value -> string list -> value option
+(** Find the sub-document addressed by the given path. Returns
+    [None] if the path is invalid. *)
 
 val update: value -> string list -> value option -> value
 (** Update the sub-document addressed by the given path. If the


### PR DESCRIPTION
Let's leave the interface rev from `find` -> `find_exn` to a future major revision. This just adds a `find_opt` in the style of the OCaml stdlib (e.g. List.assoc_opt).  Also turns an assert failure into a Parse failure.