### PR TITLE
Provide *_result variants of reading functions with informative errors

### DIFF
--- a/ezjsonm.opam
+++ b/ezjsonm.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ezjsonm"
 doc: "https://mirage.github.io/ezjsonm/"
 bug-reports: "https://github.com/mirage/ezjsonm/issues"
 depends: [
-  "ocaml" {>="4.04.0"}
+  "ocaml" {>="4.08.0"}
   "dune" {>= "2.0"}
   "alcotest" {with-test & >= "0.4.0"}
   "jsonm" {>= "1.0.0"}

--- a/lib/ezjsonm.mli
+++ b/lib/ezjsonm.mli
@@ -54,7 +54,6 @@ val unwrap: t -> value
     singleton JSON object and it return the unique element. *)
 
 (** {2 Reading JSON documents and values} *)
-
 val from_channel: in_channel -> [> t]
 (** Read a JSON document from an input channel. *)
 
@@ -69,6 +68,41 @@ val value_from_string: string -> value
 
 val value_from_src: Jsonm.src -> value
 (** Low-level function to read directly from a [Jsonm] source. *)
+
+(** {2 Reading JSON documents and values -- with proper errors} *)
+
+type error_location = (int * int) * (int * int)
+(** Error locations in a source document follow the Jsonm representation
+    of pairs of pairs [((start_line, start_col), (end_line, end_col))]
+    with 0-indexed lines and 1-indexed columns. *)
+
+type read_value_error = [
+  | `Error of error_location * Jsonm.error
+  | `Unexpected of [ `Lexeme of error_location * Jsonm.lexeme * string | `End_of_input ]
+]
+type read_error = [ read_value_error | `Not_a_t of value ]
+
+val read_error_description : [< read_error ] -> string
+(** A human-readable description of an error -- without using the error location. *)
+
+val read_error_location : [< read_error ] -> error_location option
+(** If the error is attached to a specific location in the buffer,
+    return this location. *)
+
+val from_channel_result: in_channel -> ([> t], [> read_error]) result
+(** See {!from_channel}. *)
+
+val from_string_result: string -> ([> t], [> read_error]) result
+(** See {!from_string}. *)
+
+val value_from_channel_result: in_channel -> (value, [> read_value_error]) result
+(** See {!value_from_channel}. *)
+
+val value_from_string_result: string -> (value, [> read_value_error]) result
+(** See {!value_from_string}. *)
+
+val value_from_src_result: Jsonm.src -> (value, [> read_value_error]) result
+(** See {!value_from_src}. *)
 
 (** {2 Writing JSON documents and values} *)
 


### PR DESCRIPTION
Currently Ezjsonm does not provide users with the ability to properly
report errors. In particular, the error location inside the JSON
source is provided by Jsonm and thrown away by Ezjsonm.

In ocaml-mustache I had to remove the Ezjsonm usage and turn it into Jsonm directly to provide sensible error messages: https://github.com/rgrinberg/ocaml-mustache/pull/63.

This PR provides *_result variants of reading functions
that (instead of failing in badly-documented ways) return an
informative error type in the case of reading failure, along
with simple functions to provide basic error messages to users.

Note: this PR uses the "result" type from the standard library, and as
a consequence it bumps the required OCaml version from 4.04 to
4.08. If this is judged too strong, we could use a compatibility
"result" module instead.

Finally: I would like to write tests for this PR, but I am not sure what would be the right approach. Any recommendation/preference?