### PR TITLE
Add min versions for base and cstruct

### DIFF
--- a/ezjsonm.opam
+++ b/ezjsonm.opam
@@ -16,6 +16,8 @@ depends: [
   "conf-npm" {with-test}
   "sexplib0"
   "hex"
+  "base" {>= "v0.13.0" }
+  "cstruct" {>= "3.1.0" }
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
With earlier versions of these packages this package fails to compile due to missing functions.