### PR TITLE
Fix the use of the deprecated Printf.kprintf function

### DIFF
--- a/lib/ezjsonm.ml
+++ b/lib/ezjsonm.ml
@@ -155,7 +155,7 @@ let to_channel ?minify oc json = value_to_channel ?minify oc (json :> value)
 exception Parse_error of value * string
 
 let parse_error t fmt =
-  Printf.kprintf (fun msg ->
+  Printf.ksprintf (fun msg ->
       raise (Parse_error (t, msg))
     ) fmt
 


### PR DESCRIPTION
There's one use of `Printf.kprintf` that is deprecated in OCaml 5 and causes build errors with `-Werror`. This is a trivial one-letter fix.