### PR TITLE
Update action and package versions in the CI workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '14'
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,8 +9,8 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 4.12.x
-          - 4.13.x
+          - 4.14.x
+          - 5.3.x
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - name: Install Node

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '22'
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
       - run: opam exec -- dune runtest


### PR DESCRIPTION
The main issue is the use of `setup-ocaml@v2` — it breaks the workflow because it wants to install Darcs, but Darcs is no longer available from the official repositories in Ubuntu 24.

I also took the liberty to update other actions to their latest versions, and OCaml and node.js to their latest LTS versions. If you disagree with any of those changes, I'm happy to remove them from the PR.