### PR TITLE
Remove the distinction between JSON values and documents (fixes #40)

### DIFF
--- a/lib/ezjsonm.mli
+++ b/lib/ezjsonm.mli
@@ -35,23 +35,20 @@ type value =
   | `String of string
   | `A of value list
   | `O of (string * value) list ]
-(** JSON fragments. *)
+(** JSON values. *)
 
-type t =
-  [ `A of value list
-  | `O of (string * value) list ]
-(** Well-formed JSON documents. *)
+type t = value
+(** Alias for [value] *)
 
 val value: t -> value
-(** Cast a JSON well-formed document into a JSON fragment. *)
+(** Obsolete, retained for compatibility only. *)
 
 val wrap: value -> [> t]
-(** [wrap v] wraps the value [v] into a JSON array. To use when it is
-    not possible to statically know that [v] is a value JSON value. *)
+(** [wrap v] wraps the value [v] into a JSON array. *)
 
 val unwrap: t -> value
-(** [unwrap t] is the reverse of [wrap]. It expects [t] to be a
-    singleton JSON object and it return the unique element. *)
+(** [unwrap t] is the reverse of [wrap].
+    It takes a single-item array and extracts its sole item. *)
 
 (** {2 Reading JSON documents and values} *)
 val from_channel: in_channel -> [> t]
@@ -61,10 +58,10 @@ val from_string: string -> [> t]
 (** Read a JSON document from a string. *)
 
 val value_from_channel: in_channel -> value
-(** Read a JSON value from an input channel. *)
+(** Alias for [from_channel]. *)
 
 val value_from_string: string -> value
-(** Read a JSON value from a string. *)
+(** Alias for [from_string]. *)
 
 val value_from_src: Jsonm.src -> value
 (** Low-level function to read directly from a [Jsonm] source. *)
@@ -76,11 +73,11 @@ type error_location = (int * int) * (int * int)
     of pairs of pairs [((start_line, start_col), (end_line, end_col))]
     with 0-indexed lines and 1-indexed columns. *)
 
-type read_value_error = [
+type read_error = [
   | `Error of error_location * Jsonm.error
   | `Unexpected of [ `Lexeme of error_location * Jsonm.lexeme * string | `End_of_input ]
 ]
-type read_error = [ read_value_error | `Not_a_t of value ]
+type read_value_error = read_error
 
 val read_error_description : [< read_error ] -> string
 (** A human-readable description of an error -- without using the error location. *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -89,8 +89,6 @@ module Errors = struct
     | `Unexpected (`Lexeme (loc, lexeme, msg)) ->
       Format.fprintf ppf "Unexpected lexeme %a at %a: %s"
         Jsonm.pp_lexeme lexeme pp_loc loc msg
-    | `Not_a_t _v ->
-      Format.fprintf ppf "Expected an array or object"
 
   let read_error = Alcotest.of_pp pp_read_error
   let read_result = Alcotest.result json_v read_error
@@ -108,11 +106,6 @@ module Errors = struct
                \ 1;\n\
                \ 2\n\
                ]")
-
-  let test_json_not_a_value () =
-    Alcotest.check' read_result ~msg:"not a value"
-      ~expected:(Error (`Not_a_t (`Float 42.)))
-      ~actual:(Ezjsonm.from_string_result "42")
 end
 
 let () =
@@ -129,6 +122,5 @@ let () =
     "errors", [
       "error: empty", `Quick, Errors.test_json_empty;
       "error: parse error", `Quick, Errors.test_json_parse_error;
-      "error: not a value", `Quick, Errors.test_json_not_a_value;
     ];
   ]


### PR DESCRIPTION
This PR removes the distinction between JSON documents and values, in line with the current standards and accepted practices in other libs, including Yojson.

## Motivation

Ezjsonm seems to have followed the definition from [RFC 4627](https://www.rfc-editor.org/rfc/rfc4627) (2006) and [RFC 7159](https://www.rfc-editor.org/rfc/rfc7159) (2014) — "A JSON text is a serialized object or array". That distinction also existed in the [syntax diagram on json.org](https://web.archive.org/web/20180801002125/https://www.json.org/).

However, in the fall of 2018, there were two big changes on json.org:

* First, the syntax diagram on json.org [made values acceptable at the top level](https://web.archive.org/web/20180930133721/http://json.org/).
* Second, json.org maintainers removed the mention of RFC4627 and stated that the standard was [ECMA-404](https://ecma-international.org/publications-and-standards/standards/ecma-404/).
* Third, RFC7159 was obsoleted by [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259).

The current RFC states that:

```
JSON Grammar

   A JSON text is a sequence of tokens.  The set of tokens includes six
   structural characters, strings, numbers, and three literal names.

   A JSON text is a serialized value.  Note that certain previous
   specifications of JSON constrained a JSON text to be an object or an
   array.  Implementations that generate only objects or arrays where a
   JSON text is called for will be interoperable in the sense that all
   implementations will accept these as conforming JSON texts.
```

# Solution

I tried to make the change with the smallest possible impact.

* `Ezjsonm.t` is now an alias for `Ezjsonm.value`, so most function types are unchanged.
* I kept variant types open in all places where they were open.
* I did not remove any functions to maintain compatibility with any code that might have used them.
